### PR TITLE
fix(oa): resolve issue decrypting with oa lib

### DIFF
--- a/trade_portal/trade_portal/documents/services.py
+++ b/trade_portal/trade_portal/documents/services.py
@@ -42,9 +42,9 @@ class AESCipher:
         return s[:-ord(s[len(s)-1:])]
 
     def encrypt_with_params_separate(self, raw):
-        raw = self.pad(raw).encode("utf-8")
-        cipher = AES.new(self.key, AES.MODE_EAX)
-        ciphertext, tag = cipher.encrypt_and_digest(raw)
+        encoded = base64.b64encode(raw.encode("utf-8"))
+        cipher = AES.new(self.key, AES.MODE_GCM)
+        ciphertext, tag = cipher.encrypt_and_digest(encoded)
         return (
             base64.b64encode(cipher.nonce).decode("utf-8"),
             base64.b64encode(tag).decode("utf-8"),


### PR DESCRIPTION
open attestation decryption uses GCM and expects plaintext to be base64 encoded prior to encryption.

the two changes below allow me to encrypt an oa doc using trustbridge code and decrypt using oa-encryption node library (this does not work without the changes below)